### PR TITLE
fix(CSS): Remove unneeded default styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,4 @@
 div {
-    background-color: white;
-    border-color: black;
     display: flex;
     justify-content: space-between;
     border-style: solid;


### PR DESCRIPTION
Previously, there was explicit styling on divs for background-color: white and border-color: black. Remove these unneeded styles as they replicate the default settings.