### PR TITLE
fix(UI): Limit grid size to 1-100, default 16

### DIFF
--- a/etch.js
+++ b/etch.js
@@ -1,4 +1,5 @@
 function generateGrid(dimension) {
+    if (dimension > 100 || dimension < 1) dimension = 16; // make default 16
     const container = document.querySelector(".container");
     for (let i = 0; i < dimension; i++) {
         const row = document.createElement("div");


### PR DESCRIPTION
When the user is prompted for the new grid size, they are prompted to enter an integer between 1 and 100. Previously, we did not have any handling for the case where the user entered an integer outside of that range. Now, if the user enters a number outside of that range, generate a grid of the default size, 16.